### PR TITLE
Add Editorial Workflow script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ help out other communities as well.
 ## Tools
 
 - [Scheduling Mastodon Posts with GitHub actions and rtoot (`scheduled_socials_example`)](https://github.com/ropensci-org/ro-cmtoolkit/tree/main/scheduled_socials_example#readme)
+- [Editorial Workflow (`editorial_workflow`)](https://github.com/ropensci-org/ro-cmtoolkit/tree/main/editorial_workflow#readme)

--- a/editorial_workflow/EDITORIAL.R
+++ b/editorial_workflow/EDITORIAL.R
@@ -1,0 +1,38 @@
+# Clean up previous PR if necessary
+usethis::pr_finish()
+
+# Fetch current PRs interactively
+usethis::pr_fetch()
+pr <- 830             # <--- Update PR number when you get it
+pkg <- FALSE          # <--- Is this a post about a Peer-Reviewed Package?
+
+# Get the relevant md file (and check)
+(b <- gert::git_diff("HEAD^")$new |> stringr::str_subset("\\.md$"))
+
+# Open preview in browser
+browseURL(paste0("https://deploy-preview-", pr, "--ropensci.netlify.app/"))
+
+# Open PR files in browser
+browseURL(paste0("https://github.com/ropensci/roweb3/pull/", pr, "/files"))
+
+# Checklists to copy
+paste(
+  "* [ ]",
+  c(readLines("https://raw.githubusercontent.com/ropensci-org/blog-guidance/main/inst/checklists/editor-checklist.csv"),
+    if(pkg) readLines("https://raw.githubusercontent.com/ropensci-org/blog-guidance/main/inst/checklists/editor-checklist-peer-reviewed-pkg.csv"))
+) |> 
+  cat(sep = "\n")
+
+# Local checks
+roblog::ro_lint_md(b)
+roblog::ro_check_urls(b)
+spelling::spell_check_files(b, ignore = c(spelling::get_wordlist(), promoutils::pkgs()$name))
+
+# Update wordlist manually as needed - This is specific to each Editor, locally git ignored 
+# rstudioapi::navigateToFile("inst/WORDLIST")
+
+# Open file in RStudio if required
+rstudioapi::navigateToFile(b)
+
+# Wrap up
+usethis::pr_finish(pr)

--- a/editorial_workflow/README.md
+++ b/editorial_workflow/README.md
@@ -1,0 +1,24 @@
+# Editorial Workflow
+
+This is a copy of the Editorial workflow used by editors when reviewing staff
+or community blog posts to the [rOpenSci blog](https://ropensci.org/blog).
+
+This is a relatively simple workflow and a script is not even necessary. 
+However, in a Review there are quite a few minor moving pieces and this workflow
+makes it quicker to find the files, review them, and perform some of the checks.
+
+### A couple of points
+- We use `usethis::pr_XXXX()` to handle PRs
+- We use the interactive PR fetch so we don't have to know the PR number in advance
+- We use `gert::git_diff` to make a best guess of the blog post md file. 
+  It checks for new files added in this PR with the ".md" extension.
+- We use `browseURL()` to open the URLs of the preview site and the PR files 
+  (where the editor's comments will be made)
+- We fetch the checklist text from the [Blog Guide](https://blogguide.ropensci.org/) 
+  and format it to make it easy to copy from the console (used by the editor in their review)
+- This checklist is slightly different if for a Peer Reviewed Package
+- For the spell check, we ignore words which are:
+    - the name of an rOpenSci package
+    - in a local WORDLIST stored in "inst/WORDLIST" (and locally git-ignored i.e. `.git/info/exclude`)
+- We use the `rstudioapi::navigateToFile()` function to open files in RStudio as
+  needed.

--- a/editorial_workflow/README.md
+++ b/editorial_workflow/README.md
@@ -8,6 +8,7 @@ However, in a Review there are quite a few minor moving pieces and this workflow
 makes it quicker to find the files, review them, and perform some of the checks.
 
 ### A couple of points
+- This script lives locally in the blog repository (`ropensci/roweb3` for us)
 - We use `usethis::pr_XXXX()` to handle PRs
 - We use the interactive PR fetch so we don't have to know the PR number in advance
 - We use `gert::git_diff` to make a best guess of the blog post md file. 


### PR DESCRIPTION
@maelle, @yabellini This is what all the fuss has been about 🤣 

This is the Editorial Workflow script I want to find a home for. It works well here as an example of workflows that can be useful. But for me, I'll keep it locally in the ropensci/roweb3 project as I need to use it inside that git repository. 
